### PR TITLE
End of transmission: flush transport buffer

### DIFF
--- a/lib/transport/src/Tansport.cpp
+++ b/lib/transport/src/Tansport.cpp
@@ -20,3 +20,12 @@ void Transport::add_sample(int16_t sample)
     m_index = 0;
   }
 }
+
+void Transport::flush()
+{
+  if (m_index >0 )
+  {
+    send();
+    m_index = 0;
+  }
+}

--- a/lib/transport/src/Transport.h
+++ b/lib/transport/src/Transport.h
@@ -19,5 +19,6 @@ protected:
 public:
   Transport(OutputBuffer *output_buffer, size_t buffer_size);
   void add_sample(int16_t sample);
+  void flush();
   virtual bool begin() = 0;
 };

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -115,6 +115,7 @@ void Application::loop()
           m_transport->add_sample(samples[i]);
         }
       }
+      m_transport->flush();
       // finished transmitting stop the input and start the output
       Serial.println("Finished transmitting");
       m_indicator_led->set_is_flashing(false, 0xff0000);


### PR DESCRIPTION
When ending the transmission phase, some audio samples remain in the transport buffer, so they will be transmitted at the next transmission phase, which is not correct. Solution is to flush the transport buffer when ending transmission.