### PR TITLE
Wifi channel selection

### DIFF
--- a/lib/transport/src/EspNowTransport.cpp
+++ b/lib/transport/src/EspNowTransport.cpp
@@ -17,6 +17,11 @@ void receiveCallback(const uint8_t *macAddr, const uint8_t *data, int dataLen)
 
 bool EspNowTransport::begin()
 {
+  // Set Wifi channel
+  esp_wifi_set_promiscuous(true);
+  esp_wifi_set_channel(m_wifi_channel, WIFI_SECOND_CHAN_NONE);
+  esp_wifi_set_promiscuous(false);
+  
   esp_err_t result = esp_now_init();
   if (result == ESP_OK)
   {
@@ -43,9 +48,10 @@ bool EspNowTransport::begin()
   return true;
 }
 
-EspNowTransport::EspNowTransport(OutputBuffer *output_buffer) : Transport(output_buffer, MAX_ESP_NOW_PACKET_SIZE)
+EspNowTransport::EspNowTransport(OutputBuffer *output_buffer, uint8_t wifi_channel) : Transport(output_buffer, MAX_ESP_NOW_PACKET_SIZE)
 {
-  instance = this;
+  instance = this;  
+  m_wifi_channel = wifi_channel;
 }
 
 void EspNowTransport::send()

--- a/lib/transport/src/EspNowTransport.h
+++ b/lib/transport/src/EspNowTransport.h
@@ -5,6 +5,8 @@
 class OutputBuffer;
 
 class EspNowTransport: public Transport {
+private:
+  uint8_t m_wifi_channel;
 protected:
   void send();
 public:

--- a/lib/transport/src/EspNowTransport.h
+++ b/lib/transport/src/EspNowTransport.h
@@ -8,7 +8,7 @@ class EspNowTransport: public Transport {
 protected:
   void send();
 public:
-  EspNowTransport(OutputBuffer *output_buffer);
+  EspNowTransport(OutputBuffer *output_buffer, uint8_t wifi_channel);
   virtual bool begin() override;
   friend void receiveCallback(const uint8_t *macAddr, const uint8_t *data, int dataLen);
 };

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -35,7 +35,7 @@ Application::Application()
 #endif
 
 #ifdef USE_ESP_NOW
-  m_transport = new EspNowTransport(m_output_buffer);
+  m_transport = new EspNowTransport(m_output_buffer,ESP_NOW_WIFI_CHANNEL);
 #else
   m_transport = new UdpTransport(m_output_buffer);
 #endif

--- a/src/config.h
+++ b/src/config.h
@@ -39,6 +39,9 @@
 // comment out this line to use UDP
 #define USE_ESP_NOW
 
+// On which wifi channel should ESP-Now transmit? The default ESP-Now channel on ESP32 is channel 1
+#define ESP_NOW_WIFI_CHANNEL 1
+
 // i2s config for using the internal ADC
 extern i2s_config_t i2s_adc_config;
 // i2s config for reading from of I2S

--- a/src/config.h
+++ b/src/config.h
@@ -39,7 +39,7 @@
 // comment out this line to use UDP
 #define USE_ESP_NOW
 
-// On which wifi channel should ESP-Now transmit? The default ESP-Now channel on ESP32 is channel 1
+// On which wifi channel (1-11) should ESP-Now transmit? The default ESP-Now channel on ESP32 is channel 1
 #define ESP_NOW_WIFI_CHANNEL 1
 
 // i2s config for using the internal ADC


### PR DESCRIPTION
By default, ESP32 will send ESP-Now traffic on wifi channel 1. However, when there is a lot of wifi traffic on channel 1, it would be better to change the wifi channel to another one. This PR will allow this by defining the wifi channel for ESP-Now in config.h