### PR TITLE
Multiple audio channels - packet header

### DIFF
--- a/lib/transport/src/EspNowTransport.cpp
+++ b/lib/transport/src/EspNowTransport.cpp
@@ -12,7 +12,13 @@ static EspNowTransport *instance = NULL;
 void receiveCallback(const uint8_t *macAddr, const uint8_t *data, int dataLen)
 {
   // annoyingly we can't pass an param into this so we need to do a bit of hack to access the EspNowTransport instance
-  instance->m_output_buffer->add_samples(data, dataLen);
+  int header_size = instance->m_header_size;
+  
+  // first m_header_size bytes of m_buffer are the expected header
+  if ((dataLen > header_size) && (dataLen<=MAX_ESP_NOW_PACKET_SIZE) && (memcmp(data,instance->m_buffer,header_size) == 0)) 
+  {
+    instance->m_output_buffer->add_samples(data + header_size, dataLen - header_size);
+  }
 }
 
 bool EspNowTransport::begin()
@@ -57,7 +63,7 @@ EspNowTransport::EspNowTransport(OutputBuffer *output_buffer, uint8_t wifi_chann
 void EspNowTransport::send()
 {
 
-  esp_err_t result = esp_now_send(broadcastAddress, m_buffer, m_index);
+  esp_err_t result = esp_now_send(broadcastAddress, m_buffer, m_index + m_header_size);
   if (result != ESP_OK)
   {
     Serial.printf("Failed to send: %s\n", esp_err_to_name(result));

--- a/lib/transport/src/Tansport.cpp
+++ b/lib/transport/src/Tansport.cpp
@@ -7,14 +7,15 @@ Transport::Transport(OutputBuffer *output_buffer, size_t buffer_size)
   m_buffer_size = buffer_size;
   m_buffer = (uint8_t *)malloc(m_buffer_size);
   m_index = 0;
+  m_header_size = 0;
 }
 
 void Transport::add_sample(int16_t sample)
 {
-  m_buffer[m_index] = (sample + 32768) >> 8;
+  m_buffer[m_index+m_header_size] = (sample + 32768) >> 8;
   m_index++;
   // have we reached a full packet?
-  if (m_index == m_buffer_size)
+  if ((m_index+m_header_size) == m_buffer_size)
   {
     send();
     m_index = 0;
@@ -27,5 +28,19 @@ void Transport::flush()
   {
     send();
     m_index = 0;
+  }
+}
+
+int Transport::set_header(const int header_size, const uint8_t *header)
+{
+  if ((header_size<m_buffer_size) && (header))
+  {
+    m_header_size = header_size;
+    memcpy(m_buffer, header, header_size);
+    return 0;
+  }
+  else
+  {
+    return -1;
   }
 }

--- a/lib/transport/src/Transport.h
+++ b/lib/transport/src/Transport.h
@@ -11,6 +11,7 @@ protected:
   uint8_t *m_buffer = NULL;
   int m_buffer_size = 0;
   int m_index = 0;
+  int m_header_size;
 
   OutputBuffer *m_output_buffer = NULL;
 
@@ -18,6 +19,7 @@ protected:
 
 public:
   Transport(OutputBuffer *output_buffer, size_t buffer_size);
+  int set_header(const int header_size, const uint8_t *header);
   void add_sample(int16_t sample);
   void flush();
   virtual bool begin() = 0;

--- a/lib/transport/src/UdpTransport.cpp
+++ b/lib/transport/src/UdpTransport.cpp
@@ -21,6 +21,10 @@ bool UdpTransport::begin()
                     // our packets contain unsigned 8 bit PCM samples
                     // so we can push them straight into the output buffer
                     this->m_output_buffer->add_samples(packet.data(), packet.length());
+                    if ((packet.length() > this->m_header_size) && (packet.length() <= MAX_UDP_SIZE) && (memcmp(packet.data(), this->m_buffer, this->m_header_size) == 0)) 
+                    {
+                      this->m_output_buffer->add_samples(packet.data() + m_header_size, packet.length() - m_header_size);
+                    }
                   });
     return true;
   }

--- a/lib/transport/src/UdpTransport.cpp
+++ b/lib/transport/src/UdpTransport.cpp
@@ -20,7 +20,6 @@ bool UdpTransport::begin()
                   {
                     // our packets contain unsigned 8 bit PCM samples
                     // so we can push them straight into the output buffer
-                    this->m_output_buffer->add_samples(packet.data(), packet.length());
                     if ((packet.length() > this->m_header_size) && (packet.length() <= MAX_UDP_SIZE) && (memcmp(packet.data(), this->m_buffer, this->m_header_size) == 0)) 
                     {
                       this->m_output_buffer->add_samples(packet.data() + m_header_size, packet.length() - m_header_size);

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -39,6 +39,9 @@ Application::Application()
 #else
   m_transport = new UdpTransport(m_output_buffer);
 #endif
+#ifdef TRANSPORT_HEADER_SIZE
+  m_transport->set_header(TRANSPORT_HEADER_SIZE,transport_header);
+#endif
   m_indicator_led = new TinyPICOIndicatorLed();
 
   if (I2S_SPEAKER_SD_PIN != -1)

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -39,9 +39,9 @@ Application::Application()
 #else
   m_transport = new UdpTransport(m_output_buffer);
 #endif
-#ifdef TRANSPORT_HEADER_SIZE
+
   m_transport->set_header(TRANSPORT_HEADER_SIZE,transport_header);
-#endif
+
   m_indicator_led = new TinyPICOIndicatorLed();
 
   if (I2S_SPEAKER_SD_PIN != -1)

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1,5 +1,9 @@
 #include "config.h"
 
+// In case each transport packet needs to start with a specific header, uncomment following line (see also config.h)
+// For example, when TRANSPORT_HEADER_SIZE is defined as 3,  define transport_header for example as {0x1F, 0xCD, 0x01};
+// uint8_t transport_header[TRANSPORT_HEADER_SIZE] = {};
+
 // i2s config for using the internal ADC
 i2s_config_t i2s_adc_config = {
     .mode = (i2s_mode_t)(I2S_MODE_MASTER | I2S_MODE_RX | I2S_MODE_ADC_BUILT_IN),

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1,8 +1,9 @@
 #include "config.h"
 
-// In case each transport packet needs to start with a specific header, uncomment following line (see also config.h)
+// In case each transport packet needs to start with a specific header, define transport_header here.
+// TRANSPORT_HEADER_SIZE needs to be defined in config.h
 // For example, when TRANSPORT_HEADER_SIZE is defined as 3,  define transport_header for example as {0x1F, 0xCD, 0x01};
-// uint8_t transport_header[TRANSPORT_HEADER_SIZE] = {};
+uint8_t transport_header[TRANSPORT_HEADER_SIZE] = {};
 
 // i2s config for using the internal ADC
 i2s_config_t i2s_adc_config = {

--- a/src/config.h
+++ b/src/config.h
@@ -43,10 +43,10 @@
 #define ESP_NOW_WIFI_CHANNEL 1
 
 // In case all transport packets need a header (to avoid interference with other applications or walkie talkie sets), 
-// uncomment the following line and define TRANSPORT_HEADER_SIZE 
-// #define TRANSPORT_HEADER_SIZE 0
-// also uncomment following line and define the transport_header in config.cpp
-// extern uint8_t transport_header[TRANSPORT_HEADER_SIZE];
+// specify TRANSPORT_HEADER_SIZE (the length in bytes of the header) in the next line, and define the transport header in config.cpp
+#define TRANSPORT_HEADER_SIZE 0
+extern uint8_t transport_header[TRANSPORT_HEADER_SIZE];
+
 
 // i2s config for using the internal ADC
 extern i2s_config_t i2s_adc_config;

--- a/src/config.h
+++ b/src/config.h
@@ -46,7 +46,7 @@
 // uncomment the following line and define TRANSPORT_HEADER_SIZE 
 // #define TRANSPORT_HEADER_SIZE 0
 // also uncomment following line and define the transport_header in config.cpp
-extern uint8_t transport_header[TRANSPORT_HEADER_SIZE];
+// extern uint8_t transport_header[TRANSPORT_HEADER_SIZE];
 
 // i2s config for using the internal ADC
 extern i2s_config_t i2s_adc_config;

--- a/src/config.h
+++ b/src/config.h
@@ -42,6 +42,12 @@
 // On which wifi channel (1-11) should ESP-Now transmit? The default ESP-Now channel on ESP32 is channel 1
 #define ESP_NOW_WIFI_CHANNEL 1
 
+// In case all transport packets need a header (to avoid interference with other applications or walkie talkie sets), 
+// uncomment the following line and define TRANSPORT_HEADER_SIZE 
+// #define TRANSPORT_HEADER_SIZE 0
+// also uncomment following line and define the transport_header in config.cpp
+extern uint8_t transport_header[TRANSPORT_HEADER_SIZE];
+
 // i2s config for using the internal ADC
 extern i2s_config_t i2s_adc_config;
 // i2s config for reading from of I2S


### PR DESCRIPTION
The audio data that is currently transmitted doesn't have a header yet, in this pull request I add a user-defined header. This has following advantages:
- When using ESP-Now, without header, the walkie talkie is receiving all data that is being transmitted. Imagine a maker faire where lots of makers are using ESP-now, this would make the walkie talkie unusable. 
- When you have multiple pairs of walkie talkies, you might want to have different audio channels. By defining different headers, this is now possible, even on the same frequency/network.

The header mechanism can be used both in ESP-Now mode as in UDP mode.

Remarkt that in a previous PR, I added a user defined wifi channel when using ESP-Now. The combination of both mechanisms (header & wifi channel) is the best way to implement different audio channels. Remark that wifi channel alone is not enough, as the chip receives quite a lot of data of adjacent wifi channels.

By default, the header size is 0, so there is no header. In config.h, the size of the header is defined by following code
`#define TRANSPORT_HEADER_SIZE 0`
and in config.cpp, the header content is defined as 
`uint8_t transport_header[TRANSPORT_HEADER_SIZE] = {};`

As an example, you can add a header of size 3: 
config.h: `#define TRANSPORT_HEADER_SIZE 3`
config.cpp: `uint8_t transport_header[TRANSPORT_HEADER_SIZE] = {0x1F, 0xCD, 0x01};`

Remark also that I added a check for the packet size
- it should have minimum the size of the header
- it may not be larger than the maximum defined size in MAX_ESP_NOW_PACKET_SIZE or MAX_UDP_SIZE. This is necessary, as a user can define MAX_ESP_NOW_PACKET_SIZE less then 250, or MAX_UDP_SIZE less then 1436. This is the case when you want to reduce latency, but then it is still possible to receive packets having the maximum packet size (sent by another application or device) which would cause a buffer overflow.