### PR TITLE
Compilation for ESP32 Arduino core v2 & ESP32C3

### DIFF
--- a/lib/audio_input/src/ADCSampler.cpp
+++ b/lib/audio_input/src/ADCSampler.cpp
@@ -1,5 +1,7 @@
 #include "ADCSampler.h"
 
+#if CONFIG_IDF_TARGET_ESP32 || CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3
+
 ADCSampler::ADCSampler(adc_unit_t adcUnit, adc1_channel_t adcChannel, const i2s_config_t &i2s_config) : I2SSampler(I2S_NUM_0, i2s_config)
 {
     m_adcUnit = adcUnit;
@@ -26,3 +28,5 @@ int ADCSampler::read(int16_t *samples, int count)
     }
     return samples_read;
 }
+
+#endif

--- a/lib/audio_input/src/ADCSampler.h
+++ b/lib/audio_input/src/ADCSampler.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <driver/adc.h>
 #include "I2SSampler.h"
 
 class ADCSampler : public I2SSampler

--- a/lib/audio_input/src/I2SMEMSSampler.cpp
+++ b/lib/audio_input/src/I2SMEMSSampler.cpp
@@ -24,8 +24,10 @@ void I2SMEMSSampler::configureI2S()
     if (m_fixSPH0645)
     {
         // FIXES for SPH0645
+#if CONFIG_IDF_TARGET_ESP32 || CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3
         REG_SET_BIT(I2S_TIMING_REG(m_i2sPort), BIT(9));
         REG_SET_BIT(I2S_CONF_REG(m_i2sPort), I2S_RX_MSB_SHIFT);
+#endif
     }
 
     i2s_set_pin(m_i2sPort, &m_i2sPins);

--- a/lib/audio_output/src/DACOutput.cpp
+++ b/lib/audio_output/src/DACOutput.cpp
@@ -7,7 +7,7 @@ void DACOutput::start(int sample_rate)
     // i2s config for writing both channels of I2S
     i2s_config_t i2s_config = {
         .mode = (i2s_mode_t)(I2S_MODE_MASTER | I2S_MODE_TX | I2S_MODE_DAC_BUILT_IN),
-        .sample_rate = sample_rate,
+        .sample_rate = (uint32_t)sample_rate,
         .bits_per_sample = I2S_BITS_PER_SAMPLE_16BIT,
         .channel_format = I2S_CHANNEL_FMT_RIGHT_LEFT,
         .communication_format = (i2s_comm_format_t)(I2S_COMM_FORMAT_I2S_MSB),

--- a/lib/audio_output/src/DACOutput.cpp
+++ b/lib/audio_output/src/DACOutput.cpp
@@ -1,5 +1,6 @@
-
 #include "DACOutput.h"
+
+#if CONFIG_IDF_TARGET_ESP32 || CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3
 
 void DACOutput::start(int sample_rate)
 {
@@ -25,3 +26,5 @@ void DACOutput::start(int sample_rate)
 
     i2s_start(I2S_NUM_0);
 }
+
+#endif

--- a/lib/audio_output/src/DACOutput.cpp
+++ b/lib/audio_output/src/DACOutput.cpp
@@ -7,7 +7,7 @@ void DACOutput::start(int sample_rate)
     // i2s config for writing both channels of I2S
     i2s_config_t i2s_config = {
         .mode = (i2s_mode_t)(I2S_MODE_MASTER | I2S_MODE_TX | I2S_MODE_DAC_BUILT_IN),
-        .sample_rate = (uint32_t)sample_rate,
+        .sample_rate = sample_rate,
         .bits_per_sample = I2S_BITS_PER_SAMPLE_16BIT,
         .channel_format = I2S_CHANNEL_FMT_RIGHT_LEFT,
         .communication_format = (i2s_comm_format_t)(I2S_COMM_FORMAT_I2S_MSB),

--- a/lib/audio_output/src/I2SOutput.cpp
+++ b/lib/audio_output/src/I2SOutput.cpp
@@ -10,7 +10,7 @@ void I2SOutput::start(int sample_rate)
     // i2s config for writing both channels of I2S
     i2s_config_t i2s_config = {
         .mode = (i2s_mode_t)(I2S_MODE_MASTER | I2S_MODE_TX),
-        .sample_rate = (uint32_t)sample_rate,
+        .sample_rate = sample_rate,
         .bits_per_sample = I2S_BITS_PER_SAMPLE_16BIT,
         .channel_format = I2S_CHANNEL_FMT_RIGHT_LEFT,
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 2, 0)

--- a/lib/audio_output/src/I2SOutput.cpp
+++ b/lib/audio_output/src/I2SOutput.cpp
@@ -13,7 +13,11 @@ void I2SOutput::start(int sample_rate)
         .sample_rate = sample_rate,
         .bits_per_sample = I2S_BITS_PER_SAMPLE_16BIT,
         .channel_format = I2S_CHANNEL_FMT_RIGHT_LEFT,
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 2, 0)
+        .communication_format = (i2s_comm_format_t)(I2S_COMM_FORMAT_STAND_MSB),
+#else
         .communication_format = (i2s_comm_format_t)(I2S_COMM_FORMAT_I2S),
+#endif
         .intr_alloc_flags = ESP_INTR_FLAG_LEVEL1,
         .dma_buf_count = 2,
         .dma_buf_len = 1024,

--- a/lib/audio_output/src/I2SOutput.cpp
+++ b/lib/audio_output/src/I2SOutput.cpp
@@ -10,7 +10,7 @@ void I2SOutput::start(int sample_rate)
     // i2s config for writing both channels of I2S
     i2s_config_t i2s_config = {
         .mode = (i2s_mode_t)(I2S_MODE_MASTER | I2S_MODE_TX),
-        .sample_rate = sample_rate,
+        .sample_rate = (uint32_t)sample_rate,
         .bits_per_sample = I2S_BITS_PER_SAMPLE_16BIT,
         .channel_format = I2S_CHANNEL_FMT_RIGHT_LEFT,
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 2, 0)

--- a/lib/audio_output/src/OutputBuffer.h
+++ b/lib/audio_output/src/OutputBuffer.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <Arduino.h>
-#include <FreeRTOS.h>
+#include <freertos/FreeRTOS.h>
 
 /**
  * @brief Circular buffer for 8 bit unsigned PCM samples

--- a/lib/indicator_led/src/IndicatorLed.cpp
+++ b/lib/indicator_led/src/IndicatorLed.cpp
@@ -1,4 +1,5 @@
-#include <FreeRTOS.h>
+#include <Arduino.h>
+#include <freertos/FreeRTOS.h>
 #include "IndicatorLed.h"
 
 void update_indicator_task(void *param)

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -5,7 +5,9 @@
 // For example, when TRANSPORT_HEADER_SIZE is defined as 3,  define transport_header for example as {0x1F, 0xCD, 0x01};
 uint8_t transport_header[TRANSPORT_HEADER_SIZE] = {};
 
+
 // i2s config for using the internal ADC
+#if CONFIG_IDF_TARGET_ESP32 || CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3
 i2s_config_t i2s_adc_config = {
     .mode = (i2s_mode_t)(I2S_MODE_MASTER | I2S_MODE_RX | I2S_MODE_ADC_BUILT_IN),
     .sample_rate = SAMPLE_RATE,
@@ -18,6 +20,7 @@ i2s_config_t i2s_adc_config = {
     .use_apll = false,
     .tx_desc_auto_clear = false,
     .fixed_mclk = 0};
+#endif
 
 // i2s config for reading from I2S
 i2s_config_t i2s_mic_Config = {

--- a/src/config.h
+++ b/src/config.h
@@ -1,5 +1,6 @@
 #include <freertos/FreeRTOS.h>
 #include <driver/i2s.h>
+#include <driver/gpio.h>
 
 // WiFi credentials
 #define WIFI_SSID << YOUR_SSID >>


### PR DESCRIPTION
The Arduino core v2 is not yet stable, but the code can already be adapted to the new IDF version (4.4). Also some changes were done to support ESP32C3 in future.