### PR TITLE
I2S microphone distortion

### DIFF
--- a/lib/audio_input/src/I2SMEMSSampler.cpp
+++ b/lib/audio_input/src/I2SMEMSSampler.cpp
@@ -43,7 +43,8 @@ int I2SMEMSSampler::read(int16_t *samples, int count)
     int samples_read = bytes_read / sizeof(int32_t);
     for (int i = 0; i < samples_read; i++)
     {
-        samples[i] = m_raw_samples[i] >> 11;
+        int32_t temp = m_raw_samples[i] >> 11;
+        samples[i] = (temp > INT16_MAX) ? INT16_MAX : (temp < -INT16_MAX) ? -INT16_MAX : (int16_t)temp;
     }
     return samples_read;
 }


### PR DESCRIPTION
The microphone (I2S) gives some strange distortion effect (noise) when it goes above maximum volume. This is caused by the 32-bit to 16-bit conversion of the audio, where the first 16 bits are simply ignored. This wrong, it should keep the maximimum 16 bit value 32767.

The distortion now has a more natural effect. But of course, the audio quality remains limited by the 8-bit transport protocol.

Probably it also improves the problems mentioned in
https://github.com/atomic14/esp32-walkie-talkie/issues/17
Remark that it should improve both ESP-now and TCP transmission.